### PR TITLE
Mostrar juego al esperar segundo jugador

### DIFF
--- a/wordsearch/public/client.js
+++ b/wordsearch/public/client.js
@@ -50,6 +50,10 @@ let currentWords = [];
 let categoryColor = '#fff';
 
 socket.on('waiting', () => {
+  const setupDiv = document.getElementById('setup');
+  const gameDiv = document.getElementById('game');
+  setupDiv.style.display = 'none';
+  gameDiv.style.display = 'block';
   document.getElementById('info').textContent = 'Esperando a segundo jugador...';
 });
 


### PR DESCRIPTION
## Summary
- Oculta la configuración y muestra el tablero mientras se espera a un segundo jugador.

## Testing
- `npm test`
- script headless que dispara "Crear" y verifica que el mensaje sea "Esperando a segundo jugador..."

------
https://chatgpt.com/codex/tasks/task_e_68bcd63201688325b73144fa9d44e711