### PR TITLE
Add diagonal and vertical word placement with client validation

### DIFF
--- a/wordsearch/.gitignore
+++ b/wordsearch/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/wordsearch/game.js
+++ b/wordsearch/game.js
@@ -6,11 +6,46 @@ function generateBoard(wordList, size = 12, numWords = 5) {
   while (words.length < numWords && available.length) {
     const index = Math.floor(Math.random() * available.length);
     const word = available.splice(index, 1)[0].toUpperCase();
-    words.push(word);
-    const row = Math.floor(Math.random() * size);
-    const col = Math.floor(Math.random() * (size - word.length));
-    for (let i = 0; i < word.length; i++) {
-      board[row][col + i] = word[i];
+    let placed = false;
+    let attempts = 0;
+    const directions = [
+      { dr: 0, dc: 1 }, // horizontal
+      { dr: 1, dc: 0 }, // vertical
+      { dr: 1, dc: 1 }  // diagonal
+    ];
+    while (!placed && attempts < 100) {
+      attempts++;
+      const dir = directions[Math.floor(Math.random() * directions.length)];
+      let row = 0;
+      let col = 0;
+      if (dir.dr === 0 && dir.dc === 1) { // horizontal
+        row = Math.floor(Math.random() * size);
+        col = Math.floor(Math.random() * (size - word.length));
+      } else if (dir.dr === 1 && dir.dc === 0) { // vertical
+        row = Math.floor(Math.random() * (size - word.length));
+        col = Math.floor(Math.random() * size);
+      } else { // diagonal
+        row = Math.floor(Math.random() * (size - word.length));
+        col = Math.floor(Math.random() * (size - word.length));
+      }
+      let collision = false;
+      for (let i = 0; i < word.length; i++) {
+        const r = row + dir.dr * i;
+        const c = col + dir.dc * i;
+        if (board[r][c] && board[r][c] !== word[i]) {
+          collision = true;
+          break;
+        }
+      }
+      if (!collision) {
+        for (let i = 0; i < word.length; i++) {
+          const r = row + dir.dr * i;
+          const c = col + dir.dc * i;
+          board[r][c] = word[i];
+        }
+        placed = true;
+        words.push(word);
+      }
     }
   }
 

--- a/wordsearch/public/client.js
+++ b/wordsearch/public/client.js
@@ -138,17 +138,37 @@ window.addEventListener('pointerup', () => {
   if (!selecting) return;
   selecting = false;
   const letters = selected.map(c => c.dataset.letter);
-  const word = letters.join('');
-  const rev = letters.slice().reverse().join('');
+  const positions = selected.map(c => [parseInt(c.dataset.row), parseInt(c.dataset.col)]);
   selected.forEach(c => c.classList.remove('selecting'));
   const player = document.getElementById('name').value;
   const room = document.getElementById('room').value;
-  const positions = selected.map(c => [c.dataset.row, c.dataset.col]);
+
+  let valid = false;
+  if (positions.length > 1) {
+    const dr = positions[1][0] - positions[0][0];
+    const dc = positions[1][1] - positions[0][1];
+    if (Math.abs(dr) <= 1 && Math.abs(dc) <= 1 && (dr !== 0 || dc !== 0)) {
+      valid = true;
+      for (let i = 2; i < positions.length; i++) {
+        if (positions[i][0] - positions[i-1][0] !== dr || positions[i][1] - positions[i-1][1] !== dc) {
+          valid = false;
+          break;
+        }
+      }
+    }
+  } else if (positions.length === 1) {
+    valid = true;
+  }
+
   let chosen = null;
-  if (currentWords.includes(word)) chosen = word;
-  else if (currentWords.includes(rev)) {
-    chosen = rev;
-    positions.reverse();
+  const word = letters.join('');
+  const rev = letters.slice().reverse().join('');
+  if (valid) {
+    if (currentWords.includes(word)) chosen = word;
+    else if (currentWords.includes(rev)) {
+      chosen = rev;
+      positions.reverse();
+    }
   }
   if (chosen) {
     socket.emit('foundWord', { room, word: chosen, player, positions });

--- a/wordsearch/test.js
+++ b/wordsearch/test.js
@@ -1,12 +1,51 @@
 const { generateBoard } = require('./game');
 
-const { board, words } = generateBoard(['TEST']);
+function findWord(board, word) {
+  const size = board.length;
+  const len = word.length;
+  const dirs = [
+    [0,1],
+    [1,0],
+    [1,1]
+  ];
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      for (const [dr, dc] of dirs) {
+        let match = true;
+        for (let i = 0; i < len; i++) {
+          const nr = r + dr * i;
+          const nc = c + dc * i;
+          if (nr >= size || nc >= size || board[nr][nc] !== word[i]) {
+            match = false;
+            break;
+          }
+        }
+        if (match) return true;
+        match = true;
+        for (let i = 0; i < len; i++) {
+          const nr = r + dr * i;
+          const nc = c + dc * i;
+          if (nr >= size || nc >= size || board[nr][nc] !== word[len - 1 - i]) {
+            match = false;
+            break;
+          }
+        }
+        if (match) return true;
+      }
+    }
+  }
+  return false;
+}
+
+const { board, words } = generateBoard(['TEST', 'WORD'], 12, 2);
 if (board.length !== 12) {
   console.error('Board size incorrect');
   process.exit(1);
 }
-if (!words.includes('TEST')) {
-  console.error('Word missing');
-  process.exit(1);
+for (const w of words) {
+  if (!findWord(board, w)) {
+    console.error('Word missing or misplaced:', w);
+    process.exit(1);
+  }
 }
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- Allow word search board to place words horizontally, vertically, or diagonally with collision and boundary checks
- Validate straight-line selections on the client so vertical and diagonal words can be detected
- Expand tests to ensure generated words appear on the board in supported directions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcedf21fb88325801730f23dd86507