### PR TITLE
feat: add multi-direction board placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+*.tmp

--- a/wordsearch/game.js
+++ b/wordsearch/game.js
@@ -1,19 +1,67 @@
 function generateBoard(wordList, size = 12, numWords = 5) {
+  // initialize empty board
   const board = Array.from({ length: size }, () => Array(size).fill(''));
   const words = [];
   const available = [...wordList];
 
+  // eight possible directions (horizontal, vertical, diagonal)
+  const directions = [
+    [0, 1],   // derecha
+    [1, 0],   // abajo
+    [0, -1],  // izquierda
+    [-1, 0],  // arriba
+    [1, 1],   // diagonal abajo-derecha
+    [-1, -1], // diagonal arriba-izquierda
+    [1, -1],  // diagonal abajo-izquierda
+    [-1, 1],  // diagonal arriba-derecha
+  ];
+
   while (words.length < numWords && available.length) {
     const index = Math.floor(Math.random() * available.length);
     const word = available.splice(index, 1)[0].toUpperCase();
-    words.push(word);
-    const row = Math.floor(Math.random() * size);
-    const col = Math.floor(Math.random() * (size - word.length));
-    for (let i = 0; i < word.length; i++) {
-      board[row][col + i] = word[i];
+
+    let placed = false;
+    let attempts = 0;
+
+    // attempt to place the word in a random direction/position
+    while (!placed && attempts < 100) {
+      attempts++;
+      const [dr, dc] = directions[Math.floor(Math.random() * directions.length)];
+      const startRow = Math.floor(Math.random() * size);
+      const startCol = Math.floor(Math.random() * size);
+
+      // check if word fits
+      let fits = true;
+      for (let i = 0; i < word.length; i++) {
+        const r = startRow + dr * i;
+        const c = startCol + dc * i;
+
+        if (r < 0 || c < 0 || r >= size || c >= size) {
+          fits = false;
+          break;
+        }
+        const current = board[r][c];
+        if (current && current !== word[i]) {
+          fits = false;
+          break;
+        }
+      }
+
+      if (!fits) continue;
+
+      // place word on board
+      for (let i = 0; i < word.length; i++) {
+        const r = startRow + dr * i;
+        const c = startCol + dc * i;
+        board[r][c] = word[i];
+      }
+      placed = true;
+      words.push(word);
     }
+    // if not placed after attempts, skip word (could be replaced by another)
   }
 
+  // fill remaining empty cells with random letters
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
@@ -22,6 +70,7 @@ function generateBoard(wordList, size = 12, numWords = 5) {
       }
     }
   }
+
   return { board, words };
 }
 


### PR DESCRIPTION
## Summary
- allow word placement in horizontal, vertical and diagonal directions with collision checks
- ignore node_modules and temp files

## Testing
- `cd wordsearch && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c09f4812e08325b4b7370f2c214c87